### PR TITLE
Updating all ConnectionManager.js require statements to Babel 6 format

### DIFF
--- a/server/db/ConfigDB.js
+++ b/server/db/ConfigDB.js
@@ -25,7 +25,7 @@ try {
   getKnex = extensions.getKnex;
 }
 catch (err) {
-  getKnex = require('./ConnectionManager');
+  getKnex = require('./ConnectionManager').default;
 }
 const mockDB = {
   'UIT': {

--- a/server/db/DisclosureDB.js
+++ b/server/db/DisclosureDB.js
@@ -34,7 +34,7 @@ try {
   getKnex = extensions.getKnex;
 }
 catch (err) {
-  getKnex = require('./ConnectionManager');
+  getKnex = require('./ConnectionManager').default;
 }
 
 export const saveNewFinancialEntity = (dbInfo, userInfo, disclosureId, financialEntity, files) => {
@@ -1126,5 +1126,3 @@ export const saveCurrentState = (dbInfo, userInfo, disclosureId, state) => {
         });
     });
 };
-
-

--- a/server/db/PIDB.js
+++ b/server/db/PIDB.js
@@ -26,7 +26,7 @@ try {
   getKnex = extensions.getKnex;
 }
 catch (err) {
-  getKnex = require('./ConnectionManager');
+  getKnex = require('./ConnectionManager').default;
 }
 
 const queryUsingIndex = (knex, term) => {

--- a/server/db/PIReviewDB.js
+++ b/server/db/PIReviewDB.js
@@ -27,7 +27,7 @@ try {
   getKnex = extensions.getKnex;
 }
 catch (err) {
-  getKnex = require('./ConnectionManager');
+  getKnex = require('./ConnectionManager').default;
 }
 
 export const verifyReviewIsForUser = (dbInfo, reviewId, userId) => {

--- a/server/db/ProjectDB.js
+++ b/server/db/ProjectDB.js
@@ -23,7 +23,7 @@ try {
   getKnex = extensions.getKnex;
 }
 catch (err) {
-  getKnex = require('./ConnectionManager');
+  getKnex = require('./ConnectionManager').default;
 }
 
 export const getProjects = (dbInfo, userId) => {
@@ -120,7 +120,7 @@ const saveProjectPersons = (dbInfo, persons, projectId) => {
 
         return Promise.all(queries);
       }
-      
+
       if (personIdResult.length > 0) {
         return disableAllPersonsForProject(dbInfo, projectId);
       }

--- a/server/db/TravelLogDB.js
+++ b/server/db/TravelLogDB.js
@@ -27,7 +27,7 @@ try {
   getKnex = extensions.getKnex;
 }
 catch (err) {
-  getKnex = require('./ConnectionManager');
+  getKnex = require('./ConnectionManager').default;
 }
 
 export const getTravelLogEntries = (dbInfo, userId, sortColumn, sortDirection, filter) => {


### PR DESCRIPTION
It looks like all require('research-extensions') statements were updated to Babel 6 syntax in https://github.com/kuali/research-coi/commit/d6fedb34f1cac4776d517297d05997d3e1d83f7c, but the same wasn't done for all instances of require('./ConnectionManager'). This fix updates those as well.