### PR TITLE
Changing 3rd migration script to add one column at a time, since Knex…

### DIFF
--- a/db/migration/migrations/3.js
+++ b/db/migration/migrations/3.js
@@ -21,7 +21,11 @@
 exports.up = function(knex) {
   return knex.schema.table('config', function(table) {
     table.string('user_id', 40);
+  })
+  .table('config', function(table) {
     table.string('user_name', 100);
+  })
+  .table('config', function(table) {
     table.dateTime('updated_date');
   });
 };


### PR DESCRIPTION
… doesn't seem to be able to handle Oracle multi-column ALTER TABLE syntax. I don't know Knex.js well enough to know if that's just something it can't handle or if there's another way of specifying the adds to make it work for Oracle, but for the time being it seems like it would be wise to do single-column modifications to ensure cross-database compatibility.
